### PR TITLE
Solucion del bug y eliminar el campo de apellido

### DIFF
--- a/src/app/pages/auth/sign-up/signup.component.html
+++ b/src/app/pages/auth/sign-up/signup.component.html
@@ -31,19 +31,6 @@
                 Please add a valid name
               </div>
             </div>
-            <div class="form-group mb-3">
-              <label for="lastname" class="form-label mb-2">
-                Lastname
-              </label>
-              <input #lastname="ngModel" type="text" class="form-control" id="lastname" name="lastname"
-                placeholder="Lastname" [(ngModel)]="user.lastname" [ngClass]="{
-                  'is-invalid': lastname.invalid && lastname.touched,
-                  'is-valid': lastname.valid && lastname.touched
-                }" required />
-              <div *ngIf="lastname.invalid" class="invalid-feedback">
-                Please add a valid lastname
-              </div>
-            </div>
 
             <div class="form-group mb-3">
               <label for="email" class="form-label mb-2">

--- a/src/app/pages/auth/sign-up/signup.component.ts
+++ b/src/app/pages/auth/sign-up/signup.component.ts
@@ -18,7 +18,6 @@ export class SigUpComponent {
   public passwordFieldType: string = 'password';
 
   @ViewChild('name') nameModel!: NgModel;
-  @ViewChild('lastname') lastnameModel!: NgModel;
   @ViewChild('email') emailModel!: NgModel;
   @ViewChild('password') passwordModel!: NgModel;
 
@@ -37,16 +36,13 @@ export class SigUpComponent {
     if (!this.nameModel.valid) {
       this.nameModel.control.markAsTouched();
     }
-    if (!this.lastnameModel.valid) {
-      this.lastnameModel.control.markAsTouched();
-    }
     if (!this.emailModel.valid) {
       this.emailModel.control.markAsTouched();
     }
     if (!this.passwordModel.valid) {
       this.passwordModel.control.markAsTouched();
     }
-    if (this.nameModel.valid && this.lastnameModel.valid && this.emailModel.valid && this.passwordModel.valid) {
+    if (this.nameModel.valid && this.emailModel.valid && this.passwordModel.valid) {
       this.authService.signup(this.user).subscribe({
         next: () => this.validSignup = true,
         error: (err: any) => (this.signUpError = err.description),


### PR DESCRIPTION
Esta solicitud de extracción elimina el campo "apellido" del formulario de registro en `SignUpComponent`. Los cambios simplifican el formulario y su lógica de validación al eliminar los elementos HTML, las propiedades de TypeScript y las comprobaciones de validación asociados.

### Eliminación del campo "lastname":

* [`src/app/pages/auth/sign-up/signup.component.html`](diffhunk://#diff-d0fdae517ff82066d61ee33aebc0c904ebbf3ea699a2f0dee2a8f567f5e7274aL34-L46): Se eliminó el campo de entrada "lastname" y su etiqueta asociada, la lógica de validación y el mensaje de error.
* [`src/app/pages/auth/sign-up/signup.component.ts`](diffhunk://#diff-25fedc30e1894a4556bd96ec1872169cdc65ecf5b54cf6c7aa416a3cd6d32a8bL21): Se eliminó la referencia `@ViewChild` al campo "lastname" (`lastnameModel`) y su lógica de validación en el método `validateInputs`. Se actualizó la lógica condicional para excluir "lastname" de la validación general del formulario. [[1]](diffhunk://#dif25fedc30e1894a4556bd96ec1872169cdc65ecf5b54cf6c7aa416a3cd6d32a8bL21) [[2]](diffhunk://#diff-25fedc30e1894a4556bd96ec1872169cdc65ecf5b54cf6c7aa416a3cd6d32a8bL40-R45)Solución del bug, realice pruebas con super admin, creé un usuario nuevo e inicie sesión con y todo bien 🤟🏻