### PR TITLE
Eliminar la carga de la imagen de perfil del formulario de registro

### DIFF
--- a/src/app/pages/auth/sign-up/signup.component.html
+++ b/src/app/pages/auth/sign-up/signup.component.html
@@ -83,57 +83,6 @@
               </div>
             </div>
 
-            <!-- Profile Image Upload -->
-            <div class="form-group mb-3">
-              <label class="form-label mb-2">Profile Image (Optional)</label>
-              <div class="image-upload-container">
-                <!-- Hidden file input -->
-                <input 
-                  #fileInput 
-                  type="file" 
-                  accept="image/*" 
-                  (change)="onImageSelected($event)"
-                  class="d-none"
-                  id="imageUpload"
-                >
-                
-                <!-- Custom upload button -->
-                <div class="upload-area" (click)="fileInput.click()">
-                  <div *ngIf="!imagePreview" class="upload-placeholder">
-                    <div class="upload-icon">
-                      <svg width="24" height="24" fill="currentColor" viewBox="0 0 24 24">
-                        <path d="M14,2H6A2,2 0 0,0 4,4V20A2,2 0 0,0 6,22H18A2,2 0 0,0 20,20V8L14,2M18,20H6V4H13V9H18V20Z"/>
-                      </svg>
-                    </div>
-                    <p class="upload-text mb-1">Click to upload image</p>
-                    <small class="text-muted">PNG, JPG up to 5MB</small>
-                  </div>
-                  
-                  <!-- Image preview -->
-                  <div *ngIf="imagePreview" class="image-preview-container">
-                    <img [src]="imagePreview" alt="Profile preview" class="image-preview">
-                    <div class="image-overlay">
-                      <button 
-                        type="button" 
-                        class="btn btn-sm btn-danger remove-image-btn"
-                        (click)="removeImage(); $event.stopPropagation()"
-                      >
-                        <svg width="16" height="16" fill="currentColor" viewBox="0 0 24 24">
-                          <path d="M19,4H15.5L14.5,3H9.5L8.5,4H5V6H19M6,19A2,2 0 0,0 8,21H16A2,2 0 0,0 18,19V7H6V19Z"/>
-                        </svg>
-                        Remove
-                      </button>
-                    </div>
-                  </div>
-                </div>
-                
-                <!-- Error message -->
-                <div *ngIf="imageError" class="invalid-feedback d-block">
-                  {{ imageError }}
-                </div>
-              </div>
-            </div>
-
             <div class="form-group mb-0">
               <button class="btn btn-primary btn-block w-100" type="submit">
                 Sign up

--- a/src/app/pages/auth/sign-up/signup.component.ts
+++ b/src/app/pages/auth/sign-up/signup.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { Component, ViewChild, ElementRef } from '@angular/core';
+import { Component, ViewChild } from '@angular/core';
 import { FormsModule, NgModel } from '@angular/forms';
 import { Router, RouterLink } from '@angular/router';
 import { AuthService } from '../../../services/auth.service';
@@ -16,16 +16,12 @@ export class SigUpComponent {
   public signUpError!: String;
   public validSignup!: boolean;
   public passwordFieldType: string = 'password';
-  public imagePreview: string | null = null;
-  public imageError: string | null = null;
-  public selectedFile: File | null = null;
   public confirmPasswordValue: string = '';
 
   @ViewChild('name') nameModel!: NgModel;
   @ViewChild('email') emailModel!: NgModel;
   @ViewChild('password') passwordModel!: NgModel;
   @ViewChild('confirmPassword') confirmPasswordModel!: NgModel;
-  @ViewChild('fileInput') fileInput!: ElementRef<HTMLInputElement>;
 
   public user: IUser = {};
 
@@ -35,55 +31,6 @@ export class SigUpComponent {
 
   public togglePasswordVisibility(): void {
     this.passwordFieldType = this.passwordFieldType === 'password' ? 'text' : 'password';
-  }
-
-  public onImageSelected(event: Event): void {
-    const input = event.target as HTMLInputElement;
-    const file = input.files?.[0];
-    
-    this.imageError = null;
-    
-    if (!file) {
-      this.clearImage();
-      return;
-    }
-
-    // Validate file type
-    if (!file.type.startsWith('image/')) {
-      this.imageError = 'Please select a valid image file';
-      this.clearImage();
-      return;
-    }
-
-    // Validate file size (5MB max)
-    const maxSize = 5 * 1024 * 1024; // 5MB in bytes
-    if (file.size > maxSize) {
-      this.imageError = 'Image size must be less than 5MB';
-      this.clearImage();
-      return;
-    }
-
-    this.selectedFile = file;
-
-    // Create preview
-    const reader = new FileReader();
-    reader.onload = (e) => {
-      this.imagePreview = e.target?.result as string;
-    };
-    reader.readAsDataURL(file);
-  }
-
-  public removeImage(): void {
-    this.clearImage();
-    if (this.fileInput) {
-      this.fileInput.nativeElement.value = '';
-    }
-  }
-
-  private clearImage(): void {
-    this.selectedFile = null;
-    this.imagePreview = null;
-    this.imageError = null;
   }
 
   public passwordsMatch(): boolean {
@@ -106,17 +53,10 @@ export class SigUpComponent {
     }
     
     if (this.nameModel.valid && this.emailModel.valid && this.passwordModel.valid && this.confirmPasswordModel.valid && this.passwordsMatch()) {
-      if (this.selectedFile) {
-        this.authService.signupWithImage(this.user, this.selectedFile).subscribe({
-          next: () => this.validSignup = true,
-          error: (err: any) => (this.signUpError = err.description || err.message),
-        });
-      } else {
         this.authService.signup(this.user).subscribe({
           next: () => this.validSignup = true,
           error: (err: any) => (this.signUpError = err.description || err.message),
         });
-      }
     }
   }
 }


### PR DESCRIPTION
Se eliminó la función de subir imágenes de perfil del componente de registro, incluyendo elementos de la interfaz de usuario y la lógica de TypeScript relacionada. El registro ahora solo gestiona la información básica del usuario, sin gestionar imágenes.