### PR TITLE
Mueva el selector de dificultad al encabezado del tablero de rompecab…

### DIFF
--- a/src/app/pages/games/puzzle-board/puzzle-board.component.html
+++ b/src/app/pages/games/puzzle-board/puzzle-board.component.html
@@ -2,23 +2,6 @@
 <div class="puzzle-main-layout">
   <aside class="sidebar">
     <h2>Rompecabezas</h2>
-    
-    <!-- Selector de dificultad -->
-    <div class="difficulty-selector">
-      <h3>Dificultad:</h3>
-      <div class="difficulty-options">
-        @for (config of difficultyConfigs; track config.level) {
-          <button 
-            class="difficulty-option" 
-            [class.active]="isCurrentDifficulty(config.level)" 
-            (click)="changeDifficulty(config.level)"
-          >
-            {{ config.label }}
-          </button>
-        }
-      </div>
-    </div>
-
     <div class="image-selector">
       <h3>Imagen de referencia:</h3>
       <div class="image-options">
@@ -38,8 +21,17 @@
     </div>
   </aside>
   
-  <!-- Tablero en el centro -->
   <section class="puzzle-board-section">
+    <div class="difficulty-buttons">
+      @for (config of difficultyConfigs; track config.level) {
+        <button
+          (click)="changeDifficulty(config.level)"
+          [class.active]="isCurrentDifficulty(config.level)">
+          {{ config.label }}
+        </button>
+      }
+    </div>
+
     <div class="puzzle-board" [style.grid-template-columns]="'repeat(' + boardSize + ', 1fr)'">
       @for (row of range(boardSize); track row) {
         @for (col of range(boardSize); track col) {
@@ -60,7 +52,6 @@
     </div>
   </section>
   
-  <!-- Imagen de referencia a la derecha -->
   <aside class="reference-sidebar">
     <div class="reference-image">
       <h4>Referencia:</h4>

--- a/src/app/pages/games/puzzle-board/puzzle-board.component.scss
+++ b/src/app/pages/games/puzzle-board/puzzle-board.component.scss
@@ -138,13 +138,44 @@
 }
 
 .puzzle-board-section {
-  flex: 1;
   display: flex;
   flex-direction: column;
-  align-items: center;
+  gap: 12px;
+}
+
+/* Estilo de botones de dificultad igual a Sopa de Letras */
+.difficulty-buttons {
+  display: flex;
   justify-content: center;
-  padding: 20px;
-  min-height: 100vh;
+  gap: 1rem;
+  margin-bottom: 0.5rem;
+  flex-wrap: wrap;
+
+  button {
+    padding: 0.8rem 1.5rem;
+    font-size: 1.2rem;
+    font-weight: bold;
+    border-radius: 10px;
+    border: 2px solid transparent;
+    background-color: #f5f5f5;
+    cursor: pointer;
+    transition: all 0.3s ease;
+
+    &:hover {
+      background-color: #e0e0e0;
+    }
+
+    &.active {
+      background-color: #1976d2;
+      color: white;
+      border-color: #0d47a1;
+    }
+
+  /* Añade iconos como en Sopa de Letras (asumiendo orden: Fácil, Medio, Difícil) */
+  &:nth-child(1)::before { content: "🟢 "; }
+  &:nth-child(2)::before { content: "🟡 "; }
+  &:nth-child(3)::before { content: "🔴 "; }
+  }
 }
 
 .puzzle-board {

--- a/src/app/pages/games/puzzle-board/puzzle-board.component.scss
+++ b/src/app/pages/games/puzzle-board/puzzle-board.component.scss
@@ -143,7 +143,6 @@
   gap: 12px;
 }
 
-/* Estilo de botones de dificultad igual a Sopa de Letras */
 .difficulty-buttons {
   display: flex;
   justify-content: center;
@@ -171,7 +170,6 @@
       border-color: #0d47a1;
     }
 
-  /* Añade iconos como en Sopa de Letras (asumiendo orden: Fácil, Medio, Difícil) */
   &:nth-child(1)::before { content: "🟢 "; }
   &:nth-child(2)::before { content: "🟡 "; }
   &:nth-child(3)::before { content: "🔴 "; }

--- a/src/app/pages/games/puzzle-board/puzzle.game.service.ts
+++ b/src/app/pages/games/puzzle-board/puzzle.game.service.ts
@@ -73,14 +73,12 @@ export class PuzzleService {
   private difficultySubject = new BehaviorSubject<DifficultyLevel>(DifficultyLevel.EASY);
   difficulty$ = this.difficultySubject.asObservable();
 
-  // Nuevas propiedades para tracking
   private gameId: string = '';
   private playerId: string = '';
   private gameStartTime: Date = new Date();
   private timerInterval: any;
   private currentTimeElapsed: number = 0;
 
-  // Observable para el tiempo transcurrido
   private timeElapsedSubject = new BehaviorSubject<number>(0);
   timeElapsed$ = this.timeElapsedSubject.asObservable();
   
@@ -117,11 +115,9 @@ export class PuzzleService {
   }
 
   private calculateBackgroundPosition(row: number, col: number, boardSize: number): string {
-    // Calcular la posición como un porcentaje del tamaño total de la imagen
     const xPercent = (col * 100) / (boardSize - 1);
     const yPercent = (row * 100) / (boardSize - 1);
     
-    // Para tableros de 1x1, centrar la imagen
     if (boardSize === 1) {
       return '50% 50%';
     }
@@ -255,7 +251,6 @@ export class PuzzleService {
   private submitFinalGameData(completed: boolean): void {
     if (!completed) return;
     
-    // Convertir la dificultad del frontend al formato del backend
     const levelMapping = {
       'easy': 'EASY',
       'medium': 'MEDIUM', 
@@ -269,7 +264,6 @@ export class PuzzleService {
       time: this.currentTimeElapsed
     };
 
-    // Enviar datos al backend (ruta relativa, el interceptor agregará la base URL)
     this.http.post('games/score', scoreData).subscribe({
       next: (response) => {
         console.log('Puntaje guardado exitosamente:', response);
@@ -324,7 +318,6 @@ export class PuzzleService {
     return this.currentImage;
   }
 
-  // Nuevos métodos para manejar dificultad
   setDifficulty(difficulty: DifficultyLevel): void {
     this.currentDifficulty = difficulty;
     this.difficultySubject.next(difficulty);

--- a/src/app/pages/games/puzzle-board/puzzle.game.service.ts
+++ b/src/app/pages/games/puzzle-board/puzzle.game.service.ts
@@ -21,19 +21,19 @@ const DIFFICULTY_CONFIGS: Record<DifficultyLevel, DifficultyConfig> = {
     level: DifficultyLevel.EASY,
     boardSize: 3,
     maxPieces: 9,
-    label: 'Fácil (3x3)'
+    label: 'Fácil'
   },
   [DifficultyLevel.MEDIUM]: {
     level: DifficultyLevel.MEDIUM,
     boardSize: 4,
     maxPieces: 16,
-    label: 'Medio (4x4)'
+    label: 'Medio'
   },
   [DifficultyLevel.HARD]: {
     level: DifficultyLevel.HARD,
     boardSize: 5,
     maxPieces: 25,
-    label: 'Difícil (5x5)'
+    label: 'Difícil'
   }
 };
 


### PR DESCRIPTION
…ezas

Se reubicó el selector de dificultad de la barra lateral a la esquina superior derecha del tablero de rompecabezas para mejorar la claridad de la interfaz. Se actualizaron los estilos para alinear el selector correctamente y mejorar su apariencia en el nuevo diseño.