### PR TITLE
Elimino el logo de Mentana del footer y elimino duplicados del navbar

### DIFF
--- a/src/app/pages/caregiver-dashboard/caregiver-dashboard.component.html
+++ b/src/app/pages/caregiver-dashboard/caregiver-dashboard.component.html
@@ -1,21 +1,21 @@
-<div class="page">
-  <div class="dashboard-bg">
-    <div class="dashboard-overlay"></div>
-
-    <div class="dashboard-content">
-      <main class="dashboard-main">
-        <h2 class="dashboard-title">¡Bienvenido Cuidador!</h2>
-
-        <section class="dashboard-section">
-          <card-info-user
-            title="Estadísticas"
-            description="Consulta el progreso de tus usuarios."
-            buttonText="Ver estadísticas"
-            imageUrl="assets/img/dashboardUser/stats.png"
-            routerLink="/caregiver-stats">
-          </card-info-user>
-        </section>
-      </main>
-    </div>
+<div class="dashboard-bg">
+  <div class="dashboard-overlay"></div>
+  <div class="dashboard-content">
+    <main class="dashboard-main">
+      <div class="dashboard-header">
+        <h2 class="dashboard-title">¡Bienvenido, Cuidador!</h2>
+        <p class="dashboard-subtitle">Gestiona y consulta el progreso de tus usuarios de manera sencilla.</p>
+      </div>
+      <section class="dashboard-section dashboard-cards">
+        <card-info-user
+          title="Estadísticas"
+          description="Consulta el progreso de tus usuarios."
+          buttonText="Ver estadísticas"
+          imageUrl="assets/img/dashboardUser/stats.png"
+          routerLink="/caregiver-stats">
+        </card-info-user>
+        <!-- Puedes agregar más tarjetas aquí en el futuro -->
+      </section>
+    </main>
   </div>
 </div>

--- a/src/app/pages/caregiver-dashboard/caregiver-dashboard.component.scss
+++ b/src/app/pages/caregiver-dashboard/caregiver-dashboard.component.scss
@@ -1,13 +1,21 @@
+
+// Fondo y overlay globales
 .dashboard-bg {
   min-height: 100vh;
+  width: 100vw;
   position: relative;
+  background: linear-gradient(135deg, #e3f0ff 0%, #f8fafc 100%);
   overflow-x: hidden;
-  /* Fondo eliminado para usar el fondo global */
 }
 
 .dashboard-overlay {
-  /* Fondo eliminado para usar el fondo global */
-  display: none;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(13, 71, 161, 0.08);
+  z-index: 0;
 }
 
 .dashboard-content {
@@ -27,82 +35,105 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: center; /* Centrado vertical */
-  height: 100vh;            /* Ocupar toda la pantalla */
+  justify-content: flex-start;
   width: 100%;
-  max-width: 1200px;
+  max-width: 900px;
   margin: 0 auto;
-  padding: 24px 0 0 0;
+  padding: 40px 0 0 0;
   text-align: center;
 }
 
-.dashboard-title {
-  font-size: 2rem;
-  font-weight: bold;
-  color: #191d28;
-  margin-bottom: 24px;
-  text-align: center;
-}
-
-.dashboard-section {
-  display: flex; /* Usamos flex en lugar de grid para centrar una sola tarjeta */
+.dashboard-header {
+  display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: center;
-  width: 100%;
-  max-width: 600px;
-  padding: 1rem;
   margin-bottom: 2rem;
 }
 
+.dashboard-logo {
+  width: 90px;
+  height: auto;
+  margin-bottom: 1rem;
+  filter: drop-shadow(0 2px 8px rgba(13, 71, 161, 0.10));
+}
+
+.dashboard-title {
+  font-size: 2.2rem;
+  font-weight: 700;
+  color: #0d47a1;
+  margin-bottom: 0.5rem;
+  letter-spacing: 0.5px;
+}
+
+.dashboard-subtitle {
+  font-size: 1.1rem;
+  color: #4a4a4a;
+  margin-bottom: 1.5rem;
+  font-weight: 400;
+}
+
+.dashboard-section {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2rem;
+  justify-content: center;
+  align-items: stretch;
+  width: 100%;
+  max-width: 700px;
+  margin: 0 auto 2rem auto;
+}
+
+.dashboard-cards card-info-user {
+  flex: 1 1 320px;
+  max-width: 350px;
+  min-width: 260px;
+}
+
+// Tarjeta de tip (si se usa)
 .dashboard-tip {
   width: 100%;
   margin-top: 2rem;
   margin-bottom: 2rem;
 }
 
-.dashboard-card {
-  background-color: #ffffff;
-  border-radius: 16px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
-  padding: 2rem;
-  text-align: center;
-  cursor: pointer;
-  transition: transform 0.3s, box-shadow 0.3s;
+// Animación y hover para tarjetas
+.dashboard-cards card-info-user {
+  transition: transform 0.2s, box-shadow 0.2s;
+  box-shadow: 0 2px 10px rgba(13, 71, 161, 0.08);
+  border-radius: 18px;
+  background: #fff;
+}
+.dashboard-cards card-info-user:hover {
+  transform: translateY(-6px) scale(1.03);
+  box-shadow: 0 8px 24px rgba(13, 71, 161, 0.18);
 }
 
-.dashboard-card:hover {
-  transform: scale(1.1);
-  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.25);
-}
-
-.dashboard-card-image {
-  max-width: 80%;
-  height: auto;
-  margin-bottom: 1.5rem;
-}
-
-.dashboard-card-title {
-  font-size: 1.8rem;
-  font-weight: bold;
-  margin-bottom: 1rem;
-  color: #0d47a1;
-}
-
-.dashboard-card-description {
-  font-size: 1.2rem;
-  color: #555;
-  line-height: 1.6;
-}
-
-@media (max-width: 768px) {
-  .dashboard-section {
-    max-width: 90%;
-    padding: 0 1rem;
-  }
-
+// Responsive
+@media (max-width: 900px) {
   .dashboard-main {
-    padding: 1rem 0;
-    height: auto;
+    max-width: 98vw;
+    padding: 24px 0 0 0;
+  }
+  .dashboard-section {
+    max-width: 98vw;
+    gap: 1.2rem;
+  }
+}
+
+@media (max-width: 600px) {
+  .dashboard-header {
+    margin-bottom: 1.2rem;
+  }
+  .dashboard-title {
+    font-size: 1.3rem;
+  }
+  .dashboard-section {
+    flex-direction: column;
+    gap: 1rem;
+    padding: 0 0.5rem;
+  }
+  .dashboard-cards card-info-user {
+    min-width: 90vw;
+    max-width: 98vw;
   }
 }

--- a/src/app/pages/caregiver-stats/caregiver-stats.component.scss
+++ b/src/app/pages/caregiver-stats/caregiver-stats.component.scss
@@ -1,126 +1,205 @@
+
 .stats {
-  width: 100%;
-  max-width: 880px;                
-  margin-inline: auto;
-  padding-inline: var(--space-3);
-  padding-block: clamp(24px, 6vh, 64px);  
-  text-align: left;
+  width: 100vw;
+  min-height: 100vh;
+  background: linear-gradient(135deg, #e3f0ff 0%, #f8fafc 100%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
   font-family: 'Lexend', 'Noto Sans', sans-serif;
+  padding: 0 0 48px 0;
 }
 
 .stats-title {
-  font-size: clamp(1.2rem, 1rem + .8vw, 1.6rem);
+  font-size: 2rem;
   font-weight: 700;
-  color: var(--text);
-  margin: 0 0 var(--space-3);
-  text-align: center;              
+  color: #0d47a1;
+  margin: 2.5rem 0 1.5rem 0;
+  text-align: center;
+  letter-spacing: 0.5px;
 }
 
-.search { 
-  margin-bottom: var(--space-3);  
+.search {
+  width: 100%;
+  max-width: 480px;
+  margin: 0 auto 2rem auto;
+  background: #fff;
+  border-radius: 18px;
+  box-shadow: 0 2px 10px rgba(13, 71, 161, 0.08);
+  padding: 2rem 1.5rem 1.5rem 1.5rem;
 }
 
 .search-row {
-  display: grid;
-  grid-template-columns: 1fr auto auto;
-  gap: var(--space-2);             
+  display: flex;
+  gap: 1rem;
   align-items: center;
+  width: 100%;
 }
 
 .search-input {
   height: 44px;
-  padding: 0 var(--space-2);
-  border: 1px solid #d6d6d6;
-  border-radius: var(--radius);
+  padding: 0 1rem;
+  border: 1.5px solid #b6c6e3;
+  border-radius: 12px;
   font-size: 1rem;
-  background: #fff;
+  background: #f8fafc;
+  transition: border-color 0.2s;
+  flex: 1 1 0%;
 }
 .search-input:focus-visible {
-  outline: 3px solid rgba(13,71,161,.25);
+  outline: 2.5px solid #90caf9;
   outline-offset: 2px;
+  border-color: #1976d2;
 }
 
 .btn {
   height: 44px;
-  padding: 0 var(--space-2);
-  border-radius: var(--radius);
-  border: 1px solid transparent;
+  padding: 0 1.5rem;
+  border-radius: 18px; 
+  border: none;
   cursor: pointer;
   font-weight: 600;
-  line-height: 1;                  
-  min-width: 112px;                
+  font-size: 1rem;
+  background: linear-gradient(90deg, #1976d2 0%, #42a5f5 100%);
+  color: #fff;
+  box-shadow: 0 2px 8px rgba(13, 71, 161, 0.08);
+  transition: background 0.2s, filter 0.2s, box-shadow 0.2s, transform 0.15s;
+  min-width: 112px;
 }
-.btn:disabled { opacity: .6; cursor: not-allowed; }
-.btn-primary { background: var(--brand); color: #fff; }
-.btn-primary:hover { filter: brightness(1.05); }
-.btn-ghost { background: #fff; color: var(--text); border-color: #d6d6d6; }
-.btn-ghost:hover { background: #f7f7f7; }
+.btn:disabled {
+  opacity: .6;
+  cursor: not-allowed;
+}
+.btn-primary:hover,
+.btn:hover {
+  filter: brightness(1.08);
+  background: linear-gradient(90deg, #1565c0 0%, #1976d2 100%);
+  box-shadow: 0 6px 20px rgba(13, 71, 161, 0.18);
+  transform: translateY(-2px) scale(1.03);
+}
 
-.hint { margin-top: .35rem; color: #c0392b; font-size: .9rem; }
-.status { margin-top: var(--space-2); color: var(--muted); }
+
+.hint {
+  margin-top: .35rem;
+  color: #c0392b;
+  font-size: .9rem;
+}
+.status {
+  margin-top: 1rem;
+  color: #90a4ae;
+}
+
 
 .spinner {
   display: inline-block;
-  width: 1rem; height: 1rem;
-  border: 2px solid #cfcfcf;
-  border-top-color: var(--brand);
+  width: 1.1rem;
+  height: 1.1rem;
+  border: 2.5px solid #b6c6e3;
+  border-top-color: #1976d2;
   border-radius: 50%;
   animation: spin .8s linear infinite;
   margin-right: .5rem;
 }
-@keyframes spin { to { transform: rotate(360deg); } }
-
-.result-card {
-  margin-top: var(--space-3);
-  margin-bottom: clamp(24px, 6vh, 64px);
-  background: #fff;
-  border-radius: var(--radius);
-  box-shadow: var(--shadow);
-  padding: var(--space-3);
+@keyframes spin {
+  to { transform: rotate(360deg); }
 }
+
+
+.result-card, .card {
+  margin-top: 2.5rem;
+  margin-bottom: 2.5rem;
+  background: #fff;
+  border-radius: 18px;
+  box-shadow: 0 6px 24px rgba(13,71,161,0.10), 0 2px 8px rgba(13,71,161,0.04);
+  padding: 2rem 1.5rem;
+  width: 100%;
+  max-width: 480px;
+}
+
 
 .result-dl {
   display: grid;
   grid-template-columns: max-content 1fr;
-  gap: .5rem 1rem;
+  gap: .5rem 1.2rem;
   margin: 0;
 }
-.result-dl dt { font-weight: 600; color: var(--text); }
-.result-dl dd { margin: 0; color: var(--muted); }
+.result-dl dt {
+  font-weight: 600;
+  color: #0d47a1;
+}
+.result-dl dd {
+  margin: 0;
+  color: #4a4a4a;
+}
+
 
 @media (max-width: 640px) {
-  .search-row { grid-template-columns: 1fr; }
-  .btn { width: 100%; } 
+  .stats-title {
+    font-size: 1.3rem;
+    margin-top: 1.5rem;
+  }
+  .search {
+    padding: 1.2rem 0.5rem 1rem 0.5rem;
+  }
+  .search-row {
+    flex-direction: column;
+    gap: 0.7rem;
+  }
+  .btn {
+    width: 100%;
+    min-width: unset;
+  }
+  .result-card, .card {
+    padding: 1.2rem 0.5rem;
+    margin-top: 1.2rem;
+    margin-bottom: 1.2rem;
+  }
 }
+
 
 .sr-only {
-  position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px;
-  overflow: hidden; clip: rect(0,0,0,0); white-space: nowrap; border: 0;
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0,0,0,0);
+  white-space: nowrap;
+  border: 0;
 }
 
-.card {
-  background: #fff;
-  border-radius: calc(var(--radius) + 2px);
-  box-shadow: 0 6px 24px rgba(0,0,0,.06), 0 2px 8px rgba(0,0,0,.04);
-  padding: clamp(16px, 2.2vw, 24px);
-  margin-top: var(--space-3);
-}
 
 .card-title {
-  margin: 0 0 .75rem 0;
-  font-size: clamp(1.05rem, .95rem + .4vw, 1.2rem);
+  margin: 0 0 1rem 0;
+  font-size: 1.2rem;
   font-weight: 700;
-  color: var(--text);
+  color: #1976d2;
+  letter-spacing: 0.2px;
 }
 
+
 .banner {
-  display: flex; align-items: center;
-  gap: .5rem;
-  padding: .75rem var(--space-2);
-  border-radius: var(--radius);
-  margin-top: .75rem;
-  font-size: .95rem;
+  display: flex;
+  align-items: center;
+  gap: .7rem;
+  padding: .85rem 1.2rem;
+  border-radius: 12px;
+  margin-top: 1.2rem;
+  font-size: 1rem;
+  box-shadow: 0 2px 8px rgba(13, 71, 161, 0.06);
 }
-.banner-loading { background: #f4f8ff; color: #1a54b3; border: 1px solid #cfe0ff; }
-.banner-error   { background: #fff5f5; color: #b12a2a; border: 1px solid #ffd1d1; }
-.muted { color: var(--muted); }
+.banner-loading {
+  background: #f4f8ff;
+  color: #1976d2;
+  border: 1px solid #cfe0ff;
+}
+.banner-error {
+  background: #fff5f5;
+  color: #b12a2a;
+  border: 1px solid #ffd1d1;
+}
+.muted {
+  color: #90a4ae;
+}


### PR DESCRIPTION
Se eliminó el logotipo del componente de pie de página y sus estilos para un pie de página más limpio. También se eliminó la barra de navegación de la página de estadísticas de puntuación del juego y su importación desde el componente, simplificando el diseño de la página. Se actualizó la cuadrícula de usuario del panel para mostrar 3 columnas en pantallas más grandes y mejoró la capacidad de respuesta.