### PR TITLE
Agregand mejora al juego de par de cartas v2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,9 +128,4 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
-<<<<<<< HEAD
-
-# Angular cache
-=======
->>>>>>> origin/dev
 .angular/

--- a/src/app/pages/games/memorycard-game/memorycard-game.component.html
+++ b/src/app/pages/games/memorycard-game/memorycard-game.component.html
@@ -1,7 +1,26 @@
 <div class="game-container">
   <h1>🧠 Juego de Memoria</h1>
+  <div style="margin-bottom: 1rem;">
+    <puzzle-difficulty-selector
+      [configs]="difficultyConfigs"
+      [current]="currentDifficulty"
+      (difficultyChange)="onDifficultyChange($event)">
+    </puzzle-difficulty-selector>
+  </div>
+  <div class="score-panel">
+    <span>Puntaje: <strong>{{ score }}</strong></span>
+  </div>
+  <div class="content-wrap">
+    <aside class="rules-card">
+      <h3>Reglas</h3>
+      <ul>
+        <li>Equivocación: -2 puntos</li>
+        <li>Elección correcta: +2 puntos</li>
+        <li>Empareja todas las cartas para ganar</li>
+      </ul>
+    </aside>
 
-  <div class="game-board">
+    <div class="game-board">
     <div
       *ngFor="let card of cards"
       class="card"
@@ -18,9 +37,20 @@
         </div>
       </div>
     </div>
+    </div>
   </div>
-
   <button class="restart-btn" (click)="resetGame()">
     🔄 Nuevo Juego
   </button>
+  <!-- Modal de Puntaje -->
+  <div class="score-modal-backdrop" *ngIf="showScoreModal">
+    <div class="score-modal">
+      <h2>¡Juego completado!</h2>
+      <p>Tu puntaje: <strong>{{ score }}</strong></p>
+      <div class="actions">
+        <button class="btn-primary" (click)="goToGameGallery()">Volver a Game Gallery</button>
+        <button class="btn-secondary" (click)="resetGame()">Jugar de nuevo</button>
+      </div>
+    </div>
+  </div>
 </div>

--- a/src/app/pages/games/memorycard-game/memorycard-game.component.scss
+++ b/src/app/pages/games/memorycard-game/memorycard-game.component.scss
@@ -15,12 +15,39 @@
   }
 }
 
+.content-wrap {
+  position: relative;
+  width: 100%;
+  max-width: 1080px;
+  margin: 0 auto 2rem;
+  /* Reserva espacio a la izquierda para las reglas con un pequeño margen */
+  padding-left: 320px; /* 260px de ancho + ~60px de separación visual */
+}
+
+.rules-card {
+  background: #fff;
+  border-radius: 12px;
+  box-shadow: 0 4px 24px rgba(60,70,85,0.12), 0 1.5px 6px rgba(60,70,85,0.08);
+  padding: 1rem 1.25rem;
+  color: #2c3e50;
+  h3 { margin: 0 0 0.5rem; color: #0d47a1; }
+  ul { margin: 0; padding-left: 1.2rem; }
+  li { margin: 0.25rem 0; }
+  position: absolute;
+  left: -80px; /* desplaza un poco a la izquierda para que no se superponga con las cartas */
+  top: 0;
+  width: 260px;
+  z-index: 1;
+}
+
 .game-board {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
   gap: 1rem;
   max-width: 600px;
-  margin-bottom: 2rem;
+  margin: 0 auto 2rem; /* centra el tablero */
+  /* Compensar el espacio reservado a la izquierda para alinear visualmente al centro */
+  transform: translateX(-160px);
 }
 
 .card {
@@ -130,11 +157,21 @@
   }
 }
 
+/* Reducir compensación en pantallas más anchas antes del modo móvil */
+@media (max-width: 1200px) {
+  .content-wrap { padding-left: 0; }
+  .rules-card { position: static; width: 100%; margin-top: 1rem; }
+  .game-board { transform: none; }
+}
+
 // Responsividad
 @media (max-width: 768px) {
+  .content-wrap { padding-left: 0; }
+  .rules-card { position: static; width: 100%; margin-top: 1rem; }
   .game-board {
     grid-template-columns: repeat(3, 1fr);
     max-width: 400px;
+    
   }
 
   .card {
@@ -151,10 +188,56 @@
   .game-board {
     grid-template-columns: repeat(2, 1fr);
     max-width: 280px;
+    
   }
 
   .card {
     width: 100px;
     height: 100px;
   }
+}
+
+/* Modal de puntaje */
+.score-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.35);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.score-modal {
+  background: #fff;
+  border-radius: 18px;
+  box-shadow: 0 4px 24px rgba(60,70,85,0.2), 0 1.5px 6px rgba(60,70,85,0.12);
+  padding: 1.25rem 1.5rem;
+  width: min(420px, 90vw);
+  text-align: center;
+}
+
+.score-modal .actions {
+  margin-top: 1rem;
+  display: flex;
+  gap: 0.75rem;
+  justify-content: center;
+}
+
+.btn-primary {
+  background-color: #0d47a1;
+  color: #fff;
+  border: none;
+  padding: 0.6rem 1rem;
+  border-radius: 8px;
+  cursor: pointer;
+}
+
+.btn-secondary {
+  background-color: #f5f5f5;
+  color: #0d47a1;
+  border: 2px solid #0d47a1;
+  padding: 0.6rem 1rem;
+  border-radius: 8px;
+  cursor: pointer;
 }

--- a/src/app/pages/games/memorycard-game/memorycard-game.component.ts
+++ b/src/app/pages/games/memorycard-game/memorycard-game.component.ts
@@ -1,6 +1,8 @@
 import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
-
+import { DifficultySelectorComponent } from '../../../components/difficulty-selector/difficulty-selector.component';
+import { DifficultyConfig, DifficultyLevel } from '../puzzle-board/puzzle.game.service';
+import { Router } from '@angular/router';
 export interface Card {
   id: number;
   image: string;
@@ -13,41 +15,55 @@ export interface Card {
   standalone: true,
   templateUrl: './memorycard-game.component.html',
   styleUrls: ['./memorycard-game.component.scss'],
-  imports: [CommonModule],
+  imports: [CommonModule, DifficultySelectorComponent],
 })
 export class MemoryGameComponent implements OnInit {
   cards: Card[] = [];
   flippedCards: Card[] = [];
   isCheckingMatch: boolean = false;
+  score: number = 0;
+  showScoreModal: boolean = false;
+  difficultyConfigs: DifficultyConfig[] = [
+    { level: DifficultyLevel.EASY, label: 'Fácil', boardSize: 0, maxPieces: 8 },   // 4 pares
+    { level: DifficultyLevel.MEDIUM, label: 'Medio', boardSize: 0, maxPieces: 16 },// 8 pares
+    { level: DifficultyLevel.HARD, label: 'Difícil', boardSize: 0, maxPieces: 24 } // 12 pares
+  ];
+  currentDifficulty: DifficultyLevel = DifficultyLevel.EASY;
 
   ngOnInit(): void {
     this.initializeGame();
   }
 
   initializeGame(): void {
-    const images = [
-      '🐶', '🐱', '🐭', '🐼', '🐸', '🐵', '🐧', '🐦',
-      '🐶', '🐱', '🐭', '🐼', '🐸', '🐵', '🐧', '🐦',
+    this.score = 0;
+    const allImages = [
+      '🐶', '🐱', '🐭', '🐼', '🐸', '🐵', '🐧', '🐦', '🦁', '🐷', '🐰', '🐻', '�', '🦊', '�', '�', '�', '🦄', '�', '�', '�', '🦋', '�', '🦉'
     ];
-
-    this.cards = images
+    const config = this.difficultyConfigs.find(c => c.level === this.currentDifficulty)!;
+    const pairs = Math.floor((config.maxPieces || 8) / 2);
+    const images = allImages.slice(0, pairs);
+    const deck = [...images, ...images];
+    this.cards = deck
       .map((image, index) => ({
         id: index,
         image,
         isFlipped: false,
         isMatched: false,
       }))
-      .sort(() => Math.random() - 0.5); 
+      .sort(() => Math.random() - 0.5);
+  }
+
+  onDifficultyChange(level: DifficultyLevel) {
+    this.currentDifficulty = level;
+    this.resetGame();
   }
 
   flipCard(card: Card): void {
     if (this.isCheckingMatch || card.isFlipped || card.isMatched) {
       return;
     }
-
     card.isFlipped = true;
     this.flippedCards.push(card);
-
     if (this.flippedCards.length === 2) {
       this.checkForMatch();
     }
@@ -55,15 +71,19 @@ export class MemoryGameComponent implements OnInit {
 
   checkForMatch(): void {
     this.isCheckingMatch = true;
-
     const [card1, card2] = this.flippedCards;
-
     if (card1.image === card2.image) {
       card1.isMatched = true;
       card2.isMatched = true;
+      this.score += 2;
       this.flippedCards = [];
       this.isCheckingMatch = false;
+      // Verificar si el juego terminó
+      if (this.cards.every(c => c.isMatched)) {
+        this.showScoreModal = true;
+      }
     } else {
+      this.score -= 2;
       setTimeout(() => {
         card1.isFlipped = false;
         card2.isFlipped = false;
@@ -76,6 +96,15 @@ export class MemoryGameComponent implements OnInit {
   resetGame(): void {
     this.flippedCards = [];
     this.isCheckingMatch = false;
+    this.showScoreModal = false;
     this.initializeGame();
+  }
+
+  // Navegar de vuelta a la galería de juegos
+  constructor(private router: Router) {}
+
+  goToGameGallery(): void {
+    this.showScoreModal = false;
+    this.router.navigate(['/game-gallery']);
   }
 }


### PR DESCRIPTION
Selector de dificultad
Integrado DifficultySelectorComponent.
Usa los tipos oficiales DifficultyConfig y DifficultyLevel desde puzzle.game.service (corrige errores NG2/NG5).
Niveles y pares:
Fácil: 4 pares (maxPieces: 8)
Medio: 8 pares (maxPieces: 16)
Difícil: 12 pares (maxPieces: 24)
Reinicia el mazo al cambiar la dificultad.
Puntaje
+2 por pareja correcta, -2 por intento fallido.
Se reinicia al empezar partida nueva o al cambiar dificultad.
Modal de fin de juego
Aparece al emparejar todas las cartas.
Muestra el puntaje final.
Acciones: Volver a Game Gallery y Jugar de nuevo.
UI/UX
Tablero centrado visualmente.
Tarjeta de “Reglas” (Equivocación: -2, Correcta: +2, Completa todas) con esquinas redondeadas y sombra, ubicada lateralmente (responsive).
Botón “Nuevo juego” y textos alineados con el estilo Mentana.
Limpieza técnica
Se eliminan definiciones locales duplicadas de tipos y se unifican imports.
Código organizado y sin comentarios innecesarios.